### PR TITLE
feat: basic structure for Profile component

### DIFF
--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,5 +1,13 @@
 import React from 'react';
+import ReservedRockets from './ReservedRockets';
+import './Profile.scss';
 
-const Profile = () => <main className="main">Under construction</main>;
+const Profile = () => (
+  <main className="main profile">
+    <ReservedRockets />
+    {/* for missions */}
+    <section />
+  </main>
+);
 
 export default Profile;

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -4,9 +4,9 @@ import './Profile.scss';
 
 const Profile = () => (
   <main className="main profile">
-    <ReservedRockets />
     {/* for missions */}
     <section />
+    <ReservedRockets />
   </main>
 );
 

--- a/src/components/Profile/Profile.scss
+++ b/src/components/Profile/Profile.scss
@@ -1,0 +1,16 @@
+.profile {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 100vh;
+  gap: 2rem;
+
+  & > * {
+    &:first-child {
+      background-color: teal;
+    }
+
+    &:nth-child(2) {
+      background-color: turquoise;
+    }
+  }
+}

--- a/src/components/Profile/ReservedRockets.jsx
+++ b/src/components/Profile/ReservedRockets.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
-const ReservedRockets = () => <section className="reserved-rockets" />;
+const ReservedRockets = () => (
+  <section className="reserved-rockets">Under construction 😂</section>
+);
 
 export default ReservedRockets;

--- a/src/components/Profile/ReservedRockets.jsx
+++ b/src/components/Profile/ReservedRockets.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ReservedRockets = () => <section className="reserved-rockets" />;
+
+export default ReservedRockets;


### PR DESCRIPTION
Here I just set up the basic structure, my approach will be creating a new component to render `ReservedRockets` and using `display: grid` to organize the profile page layout as two equally columns, what do you think?

note: `min-height` is just there to be able to visualize layout with background colors `we should remove if we agree to keep that approach`