### PR TITLE
Feat (navbar, rockets, profile) : responsiveness 

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -55,3 +55,11 @@
     }
   }
 }
+
+@media screen and (max-width: 720px) {
+  .header-title {
+    h1 {
+      display: none;
+    }
+  }
+}

--- a/src/components/Missions/Missions.scss
+++ b/src/components/Missions/Missions.scss
@@ -27,3 +27,13 @@
     background-color: #f3f3f3;
   }
 }
+
+@media screen and (max-width: 720px) {
+  .missions-table {
+    font-size: 8px;
+
+    button {
+      font-size: 8px !important;
+    }
+  }
+}

--- a/src/components/Profile/Profile.scss
+++ b/src/components/Profile/Profile.scss
@@ -4,3 +4,9 @@
   min-height: 100vh;
   gap: 2rem;
 }
+
+@media screen and (max-width: 600px) {
+  .profile {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/Profile/Profile.scss
+++ b/src/components/Profile/Profile.scss
@@ -1,6 +1,6 @@
 .profile {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(515px, 1fr));
   min-height: 100vh;
   gap: 2rem;
 }

--- a/src/components/Profile/filteredList.scss
+++ b/src/components/Profile/filteredList.scss
@@ -33,3 +33,14 @@
     }
   }
 }
+
+@media screen and (max-width: 600px) {
+  .filtered-list__list__item {
+    display: block;
+    padding: 1rem 0 1.5rem 0.5rem;
+
+    .ex-link {
+      margin: 1rem 1rem 0 0;
+    }
+  }
+}

--- a/src/components/Profile/filteredList.scss
+++ b/src/components/Profile/filteredList.scss
@@ -39,8 +39,12 @@
     display: block;
     padding: 1rem 0 1.5rem 0.5rem;
 
+    &__title {
+      margin-bottom: 10px;
+    }
+
     .ex-link {
-      margin: 1rem 1rem 0 0;
+      margin-right: 1rem;
     }
   }
 }

--- a/src/components/Rockets/Rockets.scss
+++ b/src/components/Rockets/Rockets.scss
@@ -14,6 +14,7 @@
       max-height: 350px;
       width: 100%;
       max-width: 450px;
+      margin-block: auto;
     }
 
     span {
@@ -34,6 +35,16 @@
       .rocket-description {
         font-size: 1.4rem;
       }
+    }
+  }
+}
+
+@media screen and (max-width: 1000px) {
+  .rocket-item {
+    flex-direction: column;
+
+    img {
+      max-width: 1000px !important;
     }
   }
 }

--- a/src/components/Rockets/Rockets.scss
+++ b/src/components/Rockets/Rockets.scss
@@ -43,6 +43,13 @@
   .rocket-item {
     flex-direction: column;
 
+    &__info {
+      p,
+      button {
+        font-size: 16px !important;
+      }
+    }
+
     img {
       max-width: 1000px !important;
     }


### PR DESCRIPTION
# Changes made & thinking process
I used multiple breakpoints depending on each component/page needs 
1- breakpoint for rockets: `1000px` where the content would start to overflow
2- breakpoint for navbar: `720px` where I removed `h1`, it looked okay for me 
3- breakpoint for profile: page I decided to use `auto-fit, minmax( )` for grid display to make responsiveness the breakpoint is that each column should have min-width of `515px` below that it displays each card as column view 


This PR closes #65 